### PR TITLE
fix filterwarnings: in windows longlong_scalar instead of long_scalar…

### DIFF
--- a/dios/test/test__ops__.py
+++ b/dios/test/test__ops__.py
@@ -27,8 +27,8 @@ def test__eq__(left, right):
             assert res == exp
 
 
-@pytest.mark.filterwarnings("ignore: invalid value encountered in long_scalars")
-@pytest.mark.filterwarnings("ignore: divide by zero encountered in long_scalars")
+@pytest.mark.filterwarnings("ignore: invalid value encountered in .*_scalars", category=RuntimeWarning)
+@pytest.mark.filterwarnings("ignore: divide by zero encountered in .*_scalars", category=RuntimeWarning)
 @pytest.mark.parametrize("left", diosFromMatr(DATA_ALIGNED))
 @pytest.mark.parametrize("right", diosFromMatr(DATA_ALIGNED))
 @pytest.mark.parametrize("op", OP2)
@@ -47,8 +47,8 @@ def test__op2__aligningops(left, right, op):
             assert res == exp
 
 
-@pytest.mark.filterwarnings("ignore: invalid value encountered in long_scalars")
-@pytest.mark.filterwarnings("ignore: divide by zero encountered in long_scalars")
+@pytest.mark.filterwarnings("ignore: invalid value encountered in .*_scalars", category=RuntimeWarning)
+@pytest.mark.filterwarnings("ignore: divide by zero encountered in .*_scalars", category=RuntimeWarning)
 @pytest.mark.parametrize("left", diosFromMatr(DATA_UNALIGNED))
 @pytest.mark.parametrize("right", diosFromMatr(DATA_UNALIGNED))
 @pytest.mark.parametrize("op", OPNOCOMP)


### PR DESCRIPTION
… is used in the warning message